### PR TITLE
Rephrase "About" in the menu

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -234,7 +234,7 @@ impl Window {
 
         let menu = gio::Menu::new();
         menu.append(Some("Keyboard Shortcuts"), Some("win.keyboard-shortcuts"));
-        menu.append(Some("About"), Some("win.about"));
+        menu.append(Some("About SphereView"), Some("win.about"));
 
         let popover_menu = gtk4::PopoverMenu::from_model(Some(&menu));
 


### PR DESCRIPTION
The convention for GNOME apps is to have the name of the application in the for the about menu entry.